### PR TITLE
Ignore test_not_expected_vlan_tag_drop on mellanox platform because not supported

### DIFF
--- a/tests/drop_packets/drop_packets.py
+++ b/tests/drop_packets/drop_packets.py
@@ -334,10 +334,13 @@ def test_multicast_smac_drop(do_test, ptfadapter, duthosts, rand_one_dut_hostnam
     do_test("L2", pkt, ptfadapter, ports_info, setup["neighbor_sniff_ports"], comparable_pkt=comparable_pkt)
 
 
-def test_not_expected_vlan_tag_drop(do_test, ptfadapter, setup, pkt_fields, ports_info):
+def test_not_expected_vlan_tag_drop(do_test, duthosts, rand_one_dut_hostname, ptfadapter, setup, pkt_fields, ports_info):
     """
     @summary: Create a VLAN tagged packet which VLAN ID does not match ingress port VLAN ID.
     """
+    duthost = duthosts[rand_one_dut_hostname]
+    if "mellanox" == duthost.facts["asic_type"]:
+        pytest.SKIP_COUNTERS_FOR_MLNX = True
     start_vlan_id = 2
     log_pkt_params(ports_info["dut_iface"], ports_info["dst_mac"], ports_info["src_mac"], pkt_fields["ipv4_dst"], pkt_fields["ipv4_src"])
     max_vlan_id = 1000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Adding ignore for test_not_expected_vlan_tag_drop because it is not supported on mellanox

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [x] 201911

### Approach
#### What is the motivation for this PR?
Community requested to check status of test_not_expected_vlan_tag_drop on mellanox.
It turned out that it was ignored on mellanox platform and mellanox testbeds. Upstreaming to community will synch the results
https://github.com/Azure/sonic-buildimage/issues/8518

#### How did you do it?
Add Ignore for mellanox platform
#### How did you verify/test it?
Executed the test on t0 and t1-lag 
py.test drop_packets/test_drop_counters.py::test_not_expected_vlan_tag_drop --inventory="../ansible/inventory,../ansible/veos" --host-pattern mtbc-sonic-03-2700 --module-path                ../ansible/library/ --testbed mtbc-sonic-03-2700-t0 --testbed_file ../ansible/testbed.csv                --allow_recover 
#### Any platform specific information?

SONiC Software Version: SONiC.202012.147-387ae82c5_Internal
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 387ae82c5
Build date: Mon Aug 23 09:55:32 UTC 2021
Built by: sw-r2d2-bot@r-build-sonic-ci02-243

Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700-D48C8
ASIC: mellanox
ASIC Count: 1

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
